### PR TITLE
CB2-2529 add test station validation before upsert

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3345,6 +3345,31 @@
         }
       }
     },
+    "@sideway/address": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.3.tgz",
+      "integrity": "sha512-8ncEUtmnTsMmL7z1YPB47kPUq7LpKWJNFPsRzHiIajGC5uXlWGn+AmkYPcHNl8S4tcEGx+cnORnNYaw2wvL+LQ==",
+      "requires": {
+        "@hapi/hoek": "^9.0.0"
+      },
+      "dependencies": {
+        "@hapi/hoek": {
+          "version": "9.2.1",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.2.1.tgz",
+          "integrity": "sha512-gfta+H8aziZsm8pZa0vj04KO6biEiisppNgA1kbJvFrrWu9Vm7eaUEy76DIxsuTaWvti5fkJVhllWc6ZTE+Mdw=="
+        }
+      }
+    },
+    "@sideway/formula": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.0.tgz",
+      "integrity": "sha512-vHe7wZ4NOXVfkoRb8T5otiENVlT7a3IAiw7H5M2+GO+9CDgcVUUsX1zalAztCmwyOr2RUTGJdgB+ZvSVqmdHmg=="
+    },
+    "@sideway/pinpoint": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
+      "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ=="
+    },
     "@sindresorhus/is": {
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
@@ -10818,6 +10843,33 @@
       "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.16.0.tgz",
       "integrity": "sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw==",
       "dev": true
+    },
+    "joi": {
+      "version": "17.6.0",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.6.0.tgz",
+      "integrity": "sha512-OX5dG6DTbcr/kbMFj0KGYxuew69HPcAE3K/sZpEV2nP6e/j/C0HV+HNiBPCASxdx5T7DMoa0s8UeHWMnb6n2zw==",
+      "requires": {
+        "@hapi/hoek": "^9.0.0",
+        "@hapi/topo": "^5.0.0",
+        "@sideway/address": "^4.1.3",
+        "@sideway/formula": "^3.0.0",
+        "@sideway/pinpoint": "^2.0.0"
+      },
+      "dependencies": {
+        "@hapi/hoek": {
+          "version": "9.2.1",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.2.1.tgz",
+          "integrity": "sha512-gfta+H8aziZsm8pZa0vj04KO6biEiisppNgA1kbJvFrrWu9Vm7eaUEy76DIxsuTaWvti5fkJVhllWc6ZTE+Mdw=="
+        },
+        "@hapi/topo": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.1.0.tgz",
+          "integrity": "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==",
+          "requires": {
+            "@hapi/hoek": "^9.0.0"
+          }
+        }
+      }
     },
     "js-string-escape": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "dependencies": {
     "aws-sdk": "2.1062.0",
     "aws-xray-sdk": "3.0.1",
+    "joi": "17.6.0",
     "node-yaml": "3.2.0",
     "path-parser": "4.2.0",
     "reflect-metadata": "0.1.13"

--- a/src/functions/putTestStation.ts
+++ b/src/functions/putTestStation.ts
@@ -1,8 +1,40 @@
+import Joi from "joi";
 import { TestStationService } from "../services/TestStationService";
 import { TestStationDAO } from "../models/TestStationDAO";
 
 export const putTestStation = async (testStation: any) => {
+  await validateTestStation(testStation);
   const testStationDAO = new TestStationDAO();
   const service = new TestStationService(testStationDAO);
   return await service.putTestStation(testStation);
 };
+
+async function validateTestStation(testStation: any) {
+  const schema = Joi.object({
+    testStationId: Joi.string().required(),
+    testStationPNumber: Joi.string().required(),
+    testStationStatus: Joi.any()
+      .required()
+      .valid(
+        "pending",
+        "active",
+        "suspended",
+        "termination requested",
+        "terminated"
+      ),
+    testStationName: Joi.string().required(),
+    testStationContactNumber: Joi.string().required(),
+    testStationAccessNotes: Joi.string().required(),
+    testStationGeneralNotes: Joi.string().required(),
+    testStationTown: Joi.string().required(),
+    testStationAddress: Joi.string().required(),
+    testStationPostcode: Joi.string().required(),
+    testStationLongitude: Joi.number().required(),
+    testStationLatitude: Joi.number().required(),
+    testStationType: Joi.any()
+      .required()
+      .valid("atf", "tass", "gvts", "potf", "other"),
+    testStationEmails: Joi.array().items(Joi.string()).required(),
+  });
+  await schema.validateAsync(testStation);
+}

--- a/tests/integration/getTestStationDbUpEmpty.intTest.ts
+++ b/tests/integration/getTestStationDbUpEmpty.intTest.ts
@@ -1,5 +1,5 @@
-import { populateDatabase, emptyDatabase } from "../util/dbOperations";
 import LambdaTester from "lambda-tester";
+import { populateDatabase, emptyDatabase } from "../util/dbOperations";
 import { HTTPResponse } from "../../src/models/HTTPResponse";
 import { getTestStations } from "../../src/functions/getTestStations";
 const url = "http://localhost:3004/";

--- a/tests/integration/getTestStationDbUpEmpty.intTest.ts
+++ b/tests/integration/getTestStationDbUpEmpty.intTest.ts
@@ -1,14 +1,11 @@
-import supertest from "supertest";
 import { populateDatabase, emptyDatabase } from "../util/dbOperations";
 import LambdaTester from "lambda-tester";
 import { HTTPResponse } from "../../src/models/HTTPResponse";
 import { getTestStations } from "../../src/functions/getTestStations";
 const url = "http://localhost:3004/";
-const request = supertest(url);
 
 describe("test stations", () => {
   beforeAll(async () => {
-    jest.restoreAllMocks();
     await emptyDatabase();
   });
 

--- a/tests/integration/putTestStation.intTest.ts
+++ b/tests/integration/putTestStation.intTest.ts
@@ -1,18 +1,18 @@
+import stations from "../resources/test-stations.json";
 import supertest from "supertest";
-import LambdaTester from "lambda-tester";
-import { getTestStations } from "../../src/functions/getTestStations";
-import { HTTPResponse } from "../../src/models/HTTPResponse";
 import { emptyDatabase, populateDatabase } from "../util/dbOperations";
+import { ITestStation } from "../../src/models/ITestStation";
 const url = "http://localhost:3004/";
 const request = supertest(url);
+let testStation: ITestStation;
 
 describe("getTestStation", () => {
   beforeAll(async () => {
-    jest.restoreAllMocks();
     await emptyDatabase();
   });
 
   beforeEach(async () => {
+    testStation = JSON.parse(JSON.stringify(stations[0]));
     await populateDatabase();
   });
 
@@ -28,19 +28,21 @@ describe("getTestStation", () => {
     it("get should return the updated record", async () => {
       const originalResponse = [
         {
-          testStationPNumber: "84-926821",
+          testStationPNumber: "87-1369569",
           testStationEmails: [
             "teststationname@dvsa.gov.uk",
             "teststationname1@dvsa.gov.uk",
+            "teststationname2@dvsa.gov.uk",
           ],
-          testStationId: "2",
+          testStationId: "1",
         },
       ];
 
-      const originalRes = await request.get("test-stations/84-926821");
+      const originalRes = await request.get("test-stations/87-1369569");
       expect(originalRes.status).toEqual(200);
       expect(originalRes.body).toStrictEqual(originalResponse);
 
+      testStation.testStationEmails.push("teststationname3@dvsa.gov.uk");
       const testStationUpdateEvent = {
         version: "0",
         id: "3b8d813d-9e1c-0c30-72f9-7539de987e31",
@@ -49,15 +51,7 @@ describe("getTestStation", () => {
         time: "2000-01-01T00:00:00Z",
         region: "eu-west-1",
         resources: [],
-        detail: {
-          testStationPNumber: "84-926821",
-          testStationEmails: [
-            "teststationname@dvsa.gov.uk",
-            "teststationname1@dvsa.gov.uk",
-            "teststationname2@dvsa.gov.uk",
-          ],
-          testStationId: "2",
-        },
+        detail: testStation,
       };
 
       await request
@@ -68,24 +62,30 @@ describe("getTestStation", () => {
 
       const updatedResponse = [
         {
-          testStationPNumber: "84-926821",
+          testStationPNumber: "87-1369569",
           testStationEmails: [
             "teststationname@dvsa.gov.uk",
             "teststationname1@dvsa.gov.uk",
             "teststationname2@dvsa.gov.uk",
+            "teststationname3@dvsa.gov.uk",
           ],
-          testStationId: "2",
+          testStationId: "1",
         },
       ];
 
-      const res = await request.get("test-stations/84-926821");
+      const res = await request.get("test-stations/87-1369569");
       expect(res.status).toEqual(200);
       expect(res.body).toStrictEqual(updatedResponse);
+
+      return;
     });
   });
 
   context("when inserting a record", () => {
     it("get should return the inserted record", async () => {
+      testStation.testStationId = "123-456-789";
+      testStation.testStationPNumber = "84-123456";
+
       const originalRes = await request.get("test-stations/84-123456");
       expect(originalRes.status).toEqual(200);
       expect(originalRes.body).toStrictEqual("");
@@ -98,14 +98,7 @@ describe("getTestStation", () => {
         time: "2000-01-01T00:00:00Z",
         region: "eu-west-1",
         resources: [],
-        detail: {
-          testStationPNumber: "84-123456",
-          testStationEmails: [
-            "teststationname@dvsa.gov.uk",
-            "teststationname1@dvsa.gov.uk",
-          ],
-          testStationId: "2",
-        },
+        detail: testStation,
       };
 
       await request
@@ -120,8 +113,9 @@ describe("getTestStation", () => {
           testStationEmails: [
             "teststationname@dvsa.gov.uk",
             "teststationname1@dvsa.gov.uk",
+            "teststationname2@dvsa.gov.uk",
           ],
-          testStationId: "2",
+          testStationId: "123-456-789",
         },
       ];
 

--- a/tests/integration/testStation.intTest.ts
+++ b/tests/integration/testStation.intTest.ts
@@ -8,7 +8,6 @@ const request = supertest(url);
 
 describe("getTestStation", () => {
   beforeAll(async () => {
-    jest.restoreAllMocks();
     await emptyDatabase();
   });
 

--- a/tests/integration/testStationsEmailsFunction.intTest.ts
+++ b/tests/integration/testStationsEmailsFunction.intTest.ts
@@ -6,7 +6,6 @@ import { emptyDatabase, populateDatabase } from "../util/dbOperations";
 
 describe("getTestStationsEmail", () => {
   beforeAll(async () => {
-    jest.restoreAllMocks();
     await emptyDatabase();
   });
 

--- a/tests/integration/testStationsFunction.intTest.ts
+++ b/tests/integration/testStationsFunction.intTest.ts
@@ -5,7 +5,6 @@ import testStations from "../resources/test-stations.json";
 
 describe("getTestStations", () => {
   beforeAll(async () => {
-    jest.restoreAllMocks();
     await emptyDatabase();
   });
 

--- a/tests/unit/putTestStationFunction.unitTest.ts
+++ b/tests/unit/putTestStationFunction.unitTest.ts
@@ -1,7 +1,7 @@
 import stations from "../resources/test-stations.json";
-import { TestStationService } from "../../src/services/TestStationService";
-import { putTestStation } from "../../src/functions/putTestStation";
 import { ITestStation } from "../../src/models/ITestStation";
+import { putTestStation } from "../../src/functions/putTestStation";
+import { TestStationService } from "../../src/services/TestStationService";
 
 jest.mock("../../src/services/TestStationService");
 

--- a/tests/unit/putTestStationFunction.unitTest.ts
+++ b/tests/unit/putTestStationFunction.unitTest.ts
@@ -1,10 +1,17 @@
+import stations from "../resources/test-stations.json";
 import { TestStationService } from "../../src/services/TestStationService";
-import { HTTPError } from "../../src/models/HTTPError";
 import { putTestStation } from "../../src/functions/putTestStation";
+import { ITestStation } from "../../src/models/ITestStation";
 
 jest.mock("../../src/services/TestStationService");
 
+let testStation: ITestStation;
+
 describe("putTestStation Handler", () => {
+  beforeEach(() => {
+    testStation = Object.assign({}, stations[0]);
+  });
+
   context("Service puts without exception", () => {
     it("resolves without exception", async () => {
       TestStationService.prototype.putTestStation = jest
@@ -12,7 +19,7 @@ describe("putTestStation Handler", () => {
         .mockImplementation(() => {
           return Promise.resolve();
         });
-      expect(await putTestStation({})).resolves;
+      expect(await putTestStation(testStation)).resolves;
     });
   });
 
@@ -21,15 +28,249 @@ describe("putTestStation Handler", () => {
       const errorMessage = "Bad thing happened";
       TestStationService.prototype.putTestStation = jest
         .fn()
-        .mockImplementation(() => {
-          return Promise.reject(new HTTPError(418, errorMessage));
+        .mockImplementationOnce(() => {
+          return Promise.reject(new Error(errorMessage));
         });
+      expect.assertions(2);
       try {
-        await putTestStation({});
+        await putTestStation(testStation);
       } catch (e) {
-        expect(e).toBeInstanceOf(HTTPError);
-        expect(e.statusCode).toEqual(418);
-        expect(e.body).toEqual(errorMessage);
+        expect(e).toBeInstanceOf(Error);
+        expect(e.message).toEqual(errorMessage);
+      }
+    });
+  });
+
+  context("Test station object validation", () => {
+    it("An unknown key should throw an error.", async () => {
+      const invalidTestStation: any = testStation;
+      invalidTestStation.invalidKey = "invalidValue";
+      expect.assertions(2);
+      try {
+        await putTestStation(invalidTestStation);
+      } catch (e) {
+        expect(e).toBeInstanceOf(Error);
+        expect(e.message).toEqual('"invalidKey" is not allowed');
+      }
+    });
+
+    it("An invalid status should throw an error.", async () => {
+      const invalidTestStation = testStation;
+      invalidTestStation.testStationStatus = "on holiday";
+      expect.assertions(2);
+      try {
+        await putTestStation(invalidTestStation);
+      } catch (e) {
+        expect(e).toBeInstanceOf(Error);
+        expect(e.message).toEqual(
+          '"testStationStatus" must be one of [pending, active, suspended, termination requested, terminated]'
+        );
+      }
+    });
+
+    it("An invalid type should throw an error.", async () => {
+      const invalidTestStation = testStation;
+      invalidTestStation.testStationType = "school";
+      expect.assertions(2);
+      try {
+        await putTestStation(invalidTestStation);
+      } catch (e) {
+        expect(e).toBeInstanceOf(Error);
+        expect(e.message).toEqual(
+          '"testStationType" must be one of [atf, tass, gvts, potf, other]'
+        );
+      }
+    });
+
+    it("An invalid longitude should throw an error.", async () => {
+      const invalidTestStation: any = testStation;
+      invalidTestStation.testStationLongitude = "north a bit";
+      expect.assertions(2);
+      try {
+        await putTestStation(invalidTestStation);
+      } catch (e) {
+        expect(e).toBeInstanceOf(Error);
+        expect(e.message).toEqual('"testStationLongitude" must be a number');
+      }
+    });
+
+    it("A missing testStationAccessNotes should throw an error.", async () => {
+      const invalidTestStation: any = testStation;
+      invalidTestStation.testStationAccessNotes = undefined;
+      expect.assertions(2);
+      try {
+        await putTestStation(invalidTestStation);
+      } catch (e) {
+        expect(e).toBeInstanceOf(Error);
+        expect(e.message).toEqual('"testStationAccessNotes" is required');
+      }
+    });
+
+    it("A missing testStationAddress should throw an error.", async () => {
+      const invalidTestStation: any = testStation;
+      invalidTestStation.testStationAddress = undefined;
+      expect.assertions(2);
+      try {
+        await putTestStation(invalidTestStation);
+      } catch (e) {
+        expect(e).toBeInstanceOf(Error);
+        expect(e.message).toEqual('"testStationAddress" is required');
+      }
+    });
+
+    it("A missing testStationContactNumber should throw an error.", async () => {
+      const invalidTestStation: any = testStation;
+      invalidTestStation.testStationContactNumber = undefined;
+      expect.assertions(2);
+      try {
+        await putTestStation(invalidTestStation);
+      } catch (e) {
+        expect(e).toBeInstanceOf(Error);
+        expect(e.message).toEqual('"testStationContactNumber" is required');
+      }
+    });
+
+    it("A missing testStationEmails should throw an error.", async () => {
+      const invalidTestStation: any = testStation;
+      invalidTestStation.testStationEmails = undefined;
+      expect.assertions(2);
+      try {
+        await putTestStation(invalidTestStation);
+      } catch (e) {
+        expect(e).toBeInstanceOf(Error);
+        expect(e.message).toEqual('"testStationEmails" is required');
+      }
+    });
+
+    it("A missing testStationGeneralNotes should throw an error.", async () => {
+      const invalidTestStation: any = testStation;
+      invalidTestStation.testStationGeneralNotes = undefined;
+      expect.assertions(2);
+      try {
+        await putTestStation(invalidTestStation);
+      } catch (e) {
+        expect(e).toBeInstanceOf(Error);
+        expect(e.message).toEqual('"testStationGeneralNotes" is required');
+      }
+    });
+
+    it("A missing testStationGeneralNotes should throw an error.", async () => {
+      const invalidTestStation: any = testStation;
+      invalidTestStation.testStationGeneralNotes = undefined;
+      expect.assertions(2);
+      try {
+        await putTestStation(invalidTestStation);
+      } catch (e) {
+        expect(e).toBeInstanceOf(Error);
+        expect(e.message).toEqual('"testStationGeneralNotes" is required');
+      }
+    });
+
+    it("A missing testStationId should throw an error.", async () => {
+      const invalidTestStation: any = testStation;
+      invalidTestStation.testStationId = undefined;
+      expect.assertions(2);
+      try {
+        await putTestStation(invalidTestStation);
+      } catch (e) {
+        expect(e).toBeInstanceOf(Error);
+        expect(e.message).toEqual('"testStationId" is required');
+      }
+    });
+
+    it("A missing testStationLatitude should throw an error.", async () => {
+      const invalidTestStation: any = testStation;
+      invalidTestStation.testStationLatitude = undefined;
+      expect.assertions(2);
+      try {
+        await putTestStation(invalidTestStation);
+      } catch (e) {
+        expect(e).toBeInstanceOf(Error);
+        expect(e.message).toEqual('"testStationLatitude" is required');
+      }
+    });
+
+    it("A missing testStationLongitude should throw an error.", async () => {
+      const invalidTestStation: any = testStation;
+      invalidTestStation.testStationLongitude = undefined;
+      expect.assertions(2);
+      try {
+        await putTestStation(invalidTestStation);
+      } catch (e) {
+        expect(e).toBeInstanceOf(Error);
+        expect(e.message).toEqual('"testStationLongitude" is required');
+      }
+    });
+
+    it("A missing testStationName should throw an error.", async () => {
+      const invalidTestStation: any = testStation;
+      invalidTestStation.testStationName = undefined;
+      expect.assertions(2);
+      try {
+        await putTestStation(invalidTestStation);
+      } catch (e) {
+        expect(e).toBeInstanceOf(Error);
+        expect(e.message).toEqual('"testStationName" is required');
+      }
+    });
+
+    it("A missing testStationPNumber should throw an error.", async () => {
+      const invalidTestStation: any = testStation;
+      invalidTestStation.testStationPNumber = undefined;
+      expect.assertions(2);
+      try {
+        await putTestStation(invalidTestStation);
+      } catch (e) {
+        expect(e).toBeInstanceOf(Error);
+        expect(e.message).toEqual('"testStationPNumber" is required');
+      }
+    });
+
+    it("A missing testStationPostcode should throw an error.", async () => {
+      const invalidTestStation: any = testStation;
+      invalidTestStation.testStationPostcode = undefined;
+      expect.assertions(2);
+      try {
+        await putTestStation(invalidTestStation);
+      } catch (e) {
+        expect(e).toBeInstanceOf(Error);
+        expect(e.message).toEqual('"testStationPostcode" is required');
+      }
+    });
+
+    it("A missing testStationStatus should throw an error.", async () => {
+      const invalidTestStation: any = testStation;
+      invalidTestStation.testStationStatus = undefined;
+      expect.assertions(2);
+      try {
+        await putTestStation(invalidTestStation);
+      } catch (e) {
+        expect(e).toBeInstanceOf(Error);
+        expect(e.message).toEqual('"testStationStatus" is required');
+      }
+    });
+
+    it("A missing testStationTown should throw an error.", async () => {
+      const invalidTestStation: any = testStation;
+      invalidTestStation.testStationTown = undefined;
+      expect.assertions(2);
+      try {
+        await putTestStation(invalidTestStation);
+      } catch (e) {
+        expect(e).toBeInstanceOf(Error);
+        expect(e.message).toEqual('"testStationTown" is required');
+      }
+    });
+
+    it("A missing testStationType should throw an error.", async () => {
+      const invalidTestStation: any = testStation;
+      invalidTestStation.testStationType = undefined;
+      expect.assertions(2);
+      try {
+        await putTestStation(invalidTestStation);
+      } catch (e) {
+        expect(e).toBeInstanceOf(Error);
+        expect(e.message).toEqual('"testStationType" is required');
       }
     });
   });

--- a/tests/util/dbOperations.ts
+++ b/tests/util/dbOperations.ts
@@ -1,6 +1,7 @@
-import { TestStationDAO } from "../../src/models/TestStationDAO";
-import testStations from "../resources/test-stations.json";
 import * as _ from "lodash";
+import testStations from "../resources/test-stations.json";
+import { ITestStation } from "../../src/models/ITestStation";
+import { TestStationDAO } from "../../src/models/TestStationDAO";
 
 export const populateDatabase = async () => {
   const mockBuffer = _.cloneDeep(testStations);
@@ -16,14 +17,19 @@ export const populateDatabase = async () => {
 
 export const emptyDatabase = async () => {
   const testStationDAO = new TestStationDAO();
-  const mockBuffer = _.cloneDeep(testStations).map(
-    (station) => station.testStationId
-  );
-  const batches = [];
-  while (mockBuffer.length > 0) {
-    batches.push(mockBuffer.splice(0, 25));
-  }
-  for (const batch of batches) {
-    await testStationDAO.deleteMultiple(batch);
-  }
+  let currentTestStations: ITestStation[] = [];
+  await testStationDAO.getAll(null)
+    .then(async (data: any) =>{
+      currentTestStations = data.Items;
+      const mockBuffer = _.cloneDeep(currentTestStations).map(
+        (station) => station.testStationId
+      );
+      const batches = [];
+      while (mockBuffer.length > 0) {
+        batches.push(mockBuffer.splice(0, 25));
+      }
+      for (const batch of batches) {
+        await testStationDAO.deleteMultiple(batch);
+      }
+    });
 };

--- a/tests/util/dbOperations.ts
+++ b/tests/util/dbOperations.ts
@@ -18,18 +18,17 @@ export const populateDatabase = async () => {
 export const emptyDatabase = async () => {
   const testStationDAO = new TestStationDAO();
   let currentTestStations: ITestStation[] = [];
-  await testStationDAO.getAll(null)
-    .then(async (data: any) =>{
-      currentTestStations = data.Items;
-      const mockBuffer = _.cloneDeep(currentTestStations).map(
-        (station) => station.testStationId
-      );
-      const batches = [];
-      while (mockBuffer.length > 0) {
-        batches.push(mockBuffer.splice(0, 25));
-      }
-      for (const batch of batches) {
-        await testStationDAO.deleteMultiple(batch);
-      }
-    });
+  await testStationDAO.getAll(null).then(async (data: any) => {
+    currentTestStations = data.Items;
+    const mockBuffer = _.cloneDeep(currentTestStations).map(
+      (station) => station.testStationId
+    );
+    const batches = [];
+    while (mockBuffer.length > 0) {
+      batches.push(mockBuffer.splice(0, 25));
+    }
+    for (const batch of batches) {
+      await testStationDAO.deleteMultiple(batch);
+    }
+  });
 };


### PR DESCRIPTION
Add validation of the test station object sent for upsert. Checks for required fields and two fields that only take certain values. An error is thrown if validation fails.