### PR TITLE
CB2-2529: make some test station fields non-mandatory

### DIFF
--- a/src/functions/putTestStation.ts
+++ b/src/functions/putTestStation.ts
@@ -24,13 +24,13 @@ async function validateTestStation(testStation: any) {
       ),
     testStationName: Joi.string().required(),
     testStationContactNumber: Joi.string().required(),
-    testStationAccessNotes: Joi.string(),
-    testStationGeneralNotes: Joi.string(),
+    testStationAccessNotes: Joi.string().allow(null),
+    testStationGeneralNotes: Joi.string().allow(null),
     testStationTown: Joi.string().required(),
     testStationAddress: Joi.string().required(),
     testStationPostcode: Joi.string().required(),
-    testStationLongitude: Joi.number(),
-    testStationLatitude: Joi.number(),
+    testStationLongitude: Joi.number().allow(null),
+    testStationLatitude: Joi.number().allow(null),
     testStationType: Joi.any()
       .required()
       .valid("atf", "tass", "gvts", "potf", "other"),

--- a/src/functions/putTestStation.ts
+++ b/src/functions/putTestStation.ts
@@ -24,13 +24,13 @@ async function validateTestStation(testStation: any) {
       ),
     testStationName: Joi.string().required(),
     testStationContactNumber: Joi.string().required(),
-    testStationAccessNotes: Joi.string().required(),
-    testStationGeneralNotes: Joi.string().required(),
+    testStationAccessNotes: Joi.string(),
+    testStationGeneralNotes: Joi.string(),
     testStationTown: Joi.string().required(),
     testStationAddress: Joi.string().required(),
     testStationPostcode: Joi.string().required(),
-    testStationLongitude: Joi.number().required(),
-    testStationLatitude: Joi.number().required(),
+    testStationLongitude: Joi.number(),
+    testStationLatitude: Joi.number(),
     testStationType: Joi.any()
       .required()
       .valid("atf", "tass", "gvts", "potf", "other"),

--- a/tests/unit/putTestStationFunction.unitTest.ts
+++ b/tests/unit/putTestStationFunction.unitTest.ts
@@ -94,16 +94,15 @@ describe("putTestStation Handler", () => {
       }
     });
 
-    it("A missing testStationAccessNotes should throw an error.", async () => {
+    it("A missing testStationAccessNotes should not throw an error.", async () => {
       const invalidTestStation: any = testStation;
       invalidTestStation.testStationAccessNotes = undefined;
-      expect.assertions(2);
-      try {
-        await putTestStation(invalidTestStation);
-      } catch (e) {
-        expect(e).toBeInstanceOf(Error);
-        expect(e.message).toEqual('"testStationAccessNotes" is required');
-      }
+      TestStationService.prototype.putTestStation = jest
+        .fn()
+        .mockImplementation(() => {
+          return Promise.resolve();
+        });
+      expect(await putTestStation(testStation)).resolves;
     });
 
     it("A missing testStationAddress should throw an error.", async () => {
@@ -142,28 +141,15 @@ describe("putTestStation Handler", () => {
       }
     });
 
-    it("A missing testStationGeneralNotes should throw an error.", async () => {
+    it("A missing testStationGeneralNotes should not throw an error.", async () => {
       const invalidTestStation: any = testStation;
       invalidTestStation.testStationGeneralNotes = undefined;
-      expect.assertions(2);
-      try {
-        await putTestStation(invalidTestStation);
-      } catch (e) {
-        expect(e).toBeInstanceOf(Error);
-        expect(e.message).toEqual('"testStationGeneralNotes" is required');
-      }
-    });
-
-    it("A missing testStationGeneralNotes should throw an error.", async () => {
-      const invalidTestStation: any = testStation;
-      invalidTestStation.testStationGeneralNotes = undefined;
-      expect.assertions(2);
-      try {
-        await putTestStation(invalidTestStation);
-      } catch (e) {
-        expect(e).toBeInstanceOf(Error);
-        expect(e.message).toEqual('"testStationGeneralNotes" is required');
-      }
+      TestStationService.prototype.putTestStation = jest
+        .fn()
+        .mockImplementation(() => {
+          return Promise.resolve();
+        });
+      expect(await putTestStation(testStation)).resolves;
     });
 
     it("A missing testStationId should throw an error.", async () => {
@@ -178,28 +164,26 @@ describe("putTestStation Handler", () => {
       }
     });
 
-    it("A missing testStationLatitude should throw an error.", async () => {
+    it("A missing testStationLatitude should not throw an error.", async () => {
       const invalidTestStation: any = testStation;
       invalidTestStation.testStationLatitude = undefined;
-      expect.assertions(2);
-      try {
-        await putTestStation(invalidTestStation);
-      } catch (e) {
-        expect(e).toBeInstanceOf(Error);
-        expect(e.message).toEqual('"testStationLatitude" is required');
-      }
+      TestStationService.prototype.putTestStation = jest
+        .fn()
+        .mockImplementation(() => {
+          return Promise.resolve();
+        });
+      expect(await putTestStation(testStation)).resolves;
     });
 
-    it("A missing testStationLongitude should throw an error.", async () => {
+    it("A missing testStationLongitude should not throw an error.", async () => {
       const invalidTestStation: any = testStation;
       invalidTestStation.testStationLongitude = undefined;
-      expect.assertions(2);
-      try {
-        await putTestStation(invalidTestStation);
-      } catch (e) {
-        expect(e).toBeInstanceOf(Error);
-        expect(e.message).toEqual('"testStationLongitude" is required');
-      }
+      TestStationService.prototype.putTestStation = jest
+        .fn()
+        .mockImplementation(() => {
+          return Promise.resolve();
+        });
+      expect(await putTestStation(testStation)).resolves;
     });
 
     it("A missing testStationName should throw an error.", async () => {

--- a/tests/unit/putTestStationFunction.unitTest.ts
+++ b/tests/unit/putTestStationFunction.unitTest.ts
@@ -105,6 +105,17 @@ describe("putTestStation Handler", () => {
       expect(await putTestStation(testStation)).resolves;
     });
 
+    it("A null testStationAccessNotes should not throw an error.", async () => {
+      const invalidTestStation: any = testStation;
+      invalidTestStation.testStationAccessNotes = null;
+      TestStationService.prototype.putTestStation = jest
+        .fn()
+        .mockImplementation(() => {
+          return Promise.resolve();
+        });
+      expect(await putTestStation(testStation)).resolves;
+    });
+
     it("A missing testStationAddress should throw an error.", async () => {
       const invalidTestStation: any = testStation;
       invalidTestStation.testStationAddress = undefined;
@@ -152,6 +163,17 @@ describe("putTestStation Handler", () => {
       expect(await putTestStation(testStation)).resolves;
     });
 
+    it("A null testStationGeneralNotes should not throw an error.", async () => {
+      const invalidTestStation: any = testStation;
+      invalidTestStation.testStationGeneralNotes = null;
+      TestStationService.prototype.putTestStation = jest
+        .fn()
+        .mockImplementation(() => {
+          return Promise.resolve();
+        });
+      expect(await putTestStation(testStation)).resolves;
+    });
+
     it("A missing testStationId should throw an error.", async () => {
       const invalidTestStation: any = testStation;
       invalidTestStation.testStationId = undefined;
@@ -175,9 +197,31 @@ describe("putTestStation Handler", () => {
       expect(await putTestStation(testStation)).resolves;
     });
 
+    it("A null testStationLatitude should not throw an error.", async () => {
+      const invalidTestStation: any = testStation;
+      invalidTestStation.testStationLatitude = null;
+      TestStationService.prototype.putTestStation = jest
+        .fn()
+        .mockImplementation(() => {
+          return Promise.resolve();
+        });
+      expect(await putTestStation(testStation)).resolves;
+    });
+
     it("A missing testStationLongitude should not throw an error.", async () => {
       const invalidTestStation: any = testStation;
       invalidTestStation.testStationLongitude = undefined;
+      TestStationService.prototype.putTestStation = jest
+        .fn()
+        .mockImplementation(() => {
+          return Promise.resolve();
+        });
+      expect(await putTestStation(testStation)).resolves;
+    });
+
+    it("A null testStationLongitude should not throw an error.", async () => {
+      const invalidTestStation: any = testStation;
+      invalidTestStation.testStationLongitude = null;
       TestStationService.prototype.putTestStation = jest
         .fn()
         .mockImplementation(() => {


### PR DESCRIPTION
The original rules where too restrictive. Especial when cvs-svc-update-test-stations always sends testStationAccessNotes as null.