### PR TITLE
feat(CB2-7235): add hq sample to test stations

### DIFF
--- a/src/functions/putTestStation.ts
+++ b/src/functions/putTestStation.ts
@@ -34,7 +34,7 @@ async function validateTestStation(testStation: any) {
     testStationLatitude: Joi.number().allow(null),
     testStationType: Joi.any()
       .required()
-      .valid("atf", "tass", "gvts", "potf", "other"),
+      .valid("atf", "tass", "gvts", "potf", "hq", "other"),
     testStationEmails: Joi.array().items(Joi.string()).required(),
   });
   await schema.validateAsync(testStation);

--- a/tests/integration/testStationsFunction.intTest.ts
+++ b/tests/integration/testStationsFunction.intTest.ts
@@ -15,8 +15,8 @@ describe("getTestStations", () => {
   context("when database is populated", () => {
     it("should return only the active test stations", () => {
       return LambdaTester(getTestStations).expectResolve((result: any) => {
-        expect(testStations).toHaveLength(20);
-        expect(JSON.parse(result.body)).toHaveLength(19);
+        expect(testStations).toHaveLength(21);
+        expect(JSON.parse(result.body)).toHaveLength(20);
         expect(result.statusCode).toEqual(200);
       });
     });

--- a/tests/resources/test-stations.json
+++ b/tests/resources/test-stations.json
@@ -325,5 +325,20 @@
     "testStationLatitude": 14.6489525,
     "testStationType": "atf",
     "testStationEmails": ["Cvs.Test2@dvsagov.onmicrosoft.com"]
+  }, {
+    "testStationId": "21",
+    "testStationPNumber": "14-7160003",
+    "testStationStatus": "active",
+    "testStationName": "Swansea Test HQ",
+    "testStationContactNumber": "+01 2345 67890",
+    "testStationAccessNotes": "Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit.",
+    "testStationGeneralNotes": "sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt. Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet, consectetur.",
+    "testStationTown": "Tillabéri",
+    "testStationAddress": "13 Swansea Drive",
+    "testStationPostcode": "12345-789",
+    "testStationLongitude": 4,
+    "testStationLatitude": 3,
+    "testStationType": "hq",
+    "testStationEmails": ["teststationname@dvsagov.onmicrosoft.com"]
   }
 ]

--- a/tests/unit/TestStationService.unitTest.ts
+++ b/tests/unit/TestStationService.unitTest.ts
@@ -31,7 +31,7 @@ describe("TestStationService", () => {
           return testStationService
             .getTestStationList()
             .then((returnedRecords: any) => {
-              expect(returnedRecords.length).toEqual(20);
+              expect(returnedRecords.length).toEqual(21);
             });
         });
       });

--- a/tests/unit/putTestStationFunction.unitTest.ts
+++ b/tests/unit/putTestStationFunction.unitTest.ts
@@ -77,7 +77,7 @@ describe("putTestStation Handler", () => {
       } catch (e) {
         expect(e).toBeInstanceOf(Error);
         expect(e.message).toEqual(
-          '"testStationType" must be one of [atf, tass, gvts, potf, other]'
+          '"testStationType" must be one of [atf, tass, gvts, potf, hq, other]'
         );
       }
     });


### PR DESCRIPTION
## CB2-7235

Adds a sample test station of type hq to the test stations json for tesitng
[CB2-7235](https://dvsa.atlassian.net/browse/CB2-7235)

## Checklist

- [ ] Code has been tested manually
- [ ] PR title includes the JIRA ticket number
- [ ] Branch is rebased against the latest develop
- [ ] Squashed commit contains the JIRA ticket number
